### PR TITLE
Create GitHub issues for roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Development Rules
+
+This repository follows the guidelines below for all contributions:
+
+- If an API key is required, use an environment variable and document it.
+- Maintain a `PLAN.txt` file summarizing current tasks and linking to the corresponding GitHub issues. Update this file alongside the issues whenever work progresses.
+- Keep code concise and remove unused code before committing.
+- Use typed Python where possible.
+- Before committing, ensure linting and cleanup are performed. No lingering code should remain.
+- Write tests that provide value without excess. Use GitHub workflows to run tests on shared runners.
+- Always run the test suite and ensure all tests pass before opening a pull request.
+- To interact with GitHub programmatically (e.g., creating issues), configure the environment variable `GITHUB_TOKEN` or `GH_TOKEN` with appropriate permissions.
+ - An example `curl` call for creating issues is documented in the README.

--- a/PLAN.txt
+++ b/PLAN.txt
@@ -1,0 +1,6 @@
+- [ ] Set up project skeleton with FastAPI and typing support. ([#2](https://github.com/wdvr/mcp-kayak/issues/2))
+- [ ] Implement Kayak API client for flight search. ([#3](https://github.com/wdvr/mcp-kayak/issues/3))
+- [ ] Create endpoint/tool to query flights. ([#4](https://github.com/wdvr/mcp-kayak/issues/4))
+- [ ] Add tests and GitHub Actions workflow. ([#5](https://github.com/wdvr/mcp-kayak/issues/5))
+
+GitHub issues created successfully using the `GITHUB_TOKEN` environment variable.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # mcp-kayak
+
+`mcp-kayak` is a prototype server implementing the **Model Context Protocol** (MCP). It is designed for use by agent frameworks such as Claude to query flight information. The server consumes the Kayak API (it does not implement it) to return flight options including price, duration and transfers for a given origin, destination, date and travel class. Over time it will expand to aggregate results from multiple providers.
+
+This project is inspired by [clickhouse-mcp](https://github.com/izaitsevfb/clickhouse-mcp) and will evolve to support multiple providers and parallel queries.
+
+## Development
+
+See `AGENTS.md` for contribution guidelines. Planned tasks are listed in `PLAN.txt` and linked to [GitHub issues](https://github.com/wdvr/mcp-kayak/issues).
+To create GitHub issues programmatically, set the `GITHUB_TOKEN` (or `GH_TOKEN`) environment variable with a token that has access to the repository. If the token is missing, CLI commands such as `gh issue create` will prompt for login and fail in non-interactive environments.
+Example `curl` command to create an issue:
+
+```bash
+curl -X POST https://api.github.com/repos/OWNER/REPO/issues \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer $GITHUB_TOKEN" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -d '{"title": "Issue title", "body": "Issue body"}'
+```


### PR DESCRIPTION
## Summary
- create GitHub issues using environment token
- link issue numbers in `PLAN.txt`
- reference GitHub issues from README

## Testing
- `pytest -q`
- `curl -X POST https://api.github.com/repos/wdvr/mcp-kayak/issues` with token

------
https://chatgpt.com/codex/tasks/task_e_68461e55d1d883338ff8f1582068cb1b