### PR TITLE
Implement fastmcp skeleton

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# Sample configuration for mcp-kayak
+FASTMCP_SERVER_HOST=127.0.0.1
+FASTMCP_SERVER_PORT=8000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.env

--- a/PLAN.txt
+++ b/PLAN.txt
@@ -1,4 +1,4 @@
-- [ ] Set up project skeleton with FastAPI and typing support. ([#2](https://github.com/wdvr/mcp-kayak/issues/2))
+- [x] Set up project skeleton with FastAPI and typing support. ([#2](https://github.com/wdvr/mcp-kayak/issues/2))
 - [ ] Implement Kayak API client for flight search. ([#3](https://github.com/wdvr/mcp-kayak/issues/3))
 - [ ] Create endpoint/tool to query flights. ([#4](https://github.com/wdvr/mcp-kayak/issues/4))
 - [ ] Add tests and GitHub Actions workflow. ([#5](https://github.com/wdvr/mcp-kayak/issues/5))

--- a/README.md
+++ b/README.md
@@ -17,3 +17,21 @@ curl -X POST https://api.github.com/repos/OWNER/REPO/issues \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   -d '{"title": "Issue title", "body": "Issue body"}'
 ```
+
+## Running locally
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Adjust configuration by editing `.env` if needed. The file is loaded automatically via `python-dotenv`.
+
+3. Start the server using the MCP CLI with the Inspector:
+
+```bash
+mcp dev mcp_kayak.server:server
+```
+
+The MCP Inspector will open in your browser and connect to the running server.

--- a/mcp_kayak/__init__.py
+++ b/mcp_kayak/__init__.py
@@ -1,0 +1,3 @@
+"""MCP Kayak server."""
+
+__all__ = ["app", "server"]

--- a/mcp_kayak/__main__.py
+++ b/mcp_kayak/__main__.py
@@ -1,0 +1,5 @@
+"""CLI entrypoint to run the FastMCP server."""
+from .server import server
+
+if __name__ == "__main__":
+    server.run()

--- a/mcp_kayak/server.py
+++ b/mcp_kayak/server.py
@@ -1,0 +1,27 @@
+"""FastMCP server definition for kayak."""
+from __future__ import annotations
+
+import os
+from dotenv import load_dotenv
+from fastapi import FastAPI
+from fastmcp import FastMCP
+
+# Load environment variables from .env if present
+load_dotenv()
+
+app = FastAPI(title="mcp-kayak")
+
+
+@app.get("/ping")
+async def ping() -> dict[str, bool]:
+    """Health check endpoint."""
+    return {"pong": True}
+
+
+# Convert the FastAPI application to a FastMCP server
+server: FastMCP = FastMCP.from_fastapi(app)
+
+
+if __name__ == "__main__":
+    # Running as a script will default to the transport specified in env
+    server.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastmcp
+python-dotenv
+fastapi
+pytest

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,15 @@
+import sys, os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from mcp_kayak.server import app, server
+from fastapi.testclient import TestClient
+
+
+def test_ping() -> None:
+    client = TestClient(app)
+    resp = client.get("/ping")
+    assert resp.status_code == 200
+    assert resp.json() == {"pong": True}
+
+
+def test_server_has_run() -> None:
+    assert hasattr(server, "run")


### PR DESCRIPTION
## Summary
- implement fastmcp server skeleton in `mcp_kayak` package
- add CLI entrypoint and dotenv support
- document how to run with MCP Inspector
- add requirements file
- provide basic tests
- update PLAN

## Testing
- `pip install -r requirements.txt --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684626203e00833381009d42c521eae0