### PR TITLE
Switch to Google Flights API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,3 +11,7 @@ This repository follows the guidelines below for all contributions:
 - Always run the test suite and ensure all tests pass before opening a pull request.
 - To interact with GitHub programmatically (e.g., creating issues), configure the environment variable `GITHUB_TOKEN` or `GH_TOKEN` with appropriate permissions.
  - An example `curl` call for creating issues is documented in the README.
+- When completing any GitHub issue, include `closes #<number>` or
+  `fixes #<number>` in the pull request description so the issue closes on merge.
+- When finishing issue #3 specifically, be sure the PR description contains
+  `closes #3` so GitHub automatically closes it.

--- a/PLAN.txt
+++ b/PLAN.txt
@@ -1,5 +1,5 @@
 - [x] Set up project skeleton with FastAPI and typing support. ([#2](https://github.com/wdvr/mcp-kayak/issues/2))
-- [ ] Implement Kayak API client for flight search. ([#3](https://github.com/wdvr/mcp-kayak/issues/3))
+- [x] Implement Google Flights API client for flight search. ([#3](https://github.com/wdvr/mcp-kayak/issues/3))
 - [ ] Create endpoint/tool to query flights. ([#4](https://github.com/wdvr/mcp-kayak/issues/4))
 - [ ] Add tests and GitHub Actions workflow. ([#5](https://github.com/wdvr/mcp-kayak/issues/5))
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mcp-kayak
 
-`mcp-kayak` is a prototype server implementing the **Model Context Protocol** (MCP). It is designed for use by agent frameworks such as Claude to query flight information. The server consumes the Kayak API (it does not implement it) to return flight options including price, duration and transfers for a given origin, destination, date and travel class. Over time it will expand to aggregate results from multiple providers.
+`mcp-kayak` is a prototype server implementing the **Model Context Protocol** (MCP). It is designed for use by agent frameworks such as Claude to query flight information. The server currently consumes the **Google Flights Search API** via RapidAPI to return flight options including price, duration and transfers for a given origin, destination, date and travel class. Over time it will expand to aggregate results from multiple providers.
 
 This project is inspired by [clickhouse-mcp](https://github.com/izaitsevfb/clickhouse-mcp) and will evolve to support multiple providers and parallel queries.
 
@@ -27,6 +27,8 @@ pip install -r requirements.txt
 ```
 
 2. Adjust configuration by editing `.env` if needed. The file is loaded automatically via `python-dotenv`.
+   Sign up on [RapidAPI](https://rapidapi.com/) and subscribe to one of the Google Flights Search APIs.
+   Copy the provided `X-RapidAPI-Key` and set it as `GOOGLE_FLIGHTS_API_KEY` in your environment.
 
 3. Start the server using the MCP CLI with the Inspector:
 

--- a/mcp_kayak/__init__.py
+++ b/mcp_kayak/__init__.py
@@ -1,3 +1,5 @@
 """MCP Kayak server."""
 
-__all__ = ["app", "server"]
+__all__ = ["app", "server", "GoogleFlightsClient"]
+
+from .google_flights_client import GoogleFlightsClient

--- a/mcp_kayak/google_flights_client.py
+++ b/mcp_kayak/google_flights_client.py
@@ -1,0 +1,36 @@
+"""Client for querying the Google Flights Search API via RapidAPI."""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+
+class GoogleFlightsClient:
+    """Simple client for Google Flights Search."""
+
+    BASE_URL = "https://google-flights13.p.rapidapi.com"
+
+    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+        self.api_key = api_key or os.getenv("GOOGLE_FLIGHTS_API_KEY")
+        if not self.api_key:
+            raise ValueError("GOOGLE_FLIGHTS_API_KEY missing")
+        self.base_url = base_url or self.BASE_URL
+
+    def search_flights(
+        self, origin: str, destination: str, date: str, cabin: str = "economy"
+    ) -> dict[str, Any]:
+        """Query flights from the Google Flights Search API."""
+        params = {
+            "origin": origin,
+            "destination": destination,
+            "date": date,
+            "cabin": cabin,
+        }
+        headers = {
+            "X-RapidAPI-Key": self.api_key,
+        }
+        resp = httpx.get(f"{self.base_url}/flights", params=params, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastmcp
 python-dotenv
 fastapi
+httpx
 pytest

--- a/tests/test_google_flights_client.py
+++ b/tests/test_google_flights_client.py
@@ -1,0 +1,41 @@
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import pytest
+
+from mcp_kayak.google_flights_client import GoogleFlightsClient
+
+
+def test_init_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GOOGLE_FLIGHTS_API_KEY", raising=False)
+    with pytest.raises(ValueError):
+        GoogleFlightsClient()
+
+
+def test_search_flights(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_FLIGHTS_API_KEY", "dummy")
+    called: dict[str, Any] = {}
+
+    def fake_get(url: str, params: dict[str, Any], headers: dict[str, Any], timeout: int) -> Any:
+        called["url"] = url
+        called["params"] = params
+        called["headers"] = headers
+
+        class Resp:
+            def raise_for_status(self) -> None:
+                pass
+
+            def json(self) -> dict[str, Any]:
+                return {"flights": []}
+
+        return Resp()
+
+    monkeypatch.setattr("httpx.get", fake_get)
+    client = GoogleFlightsClient()
+    result = client.search_flights("NYC", "LAX", "2024-01-01")
+    assert called["params"]["origin"] == "NYC"
+    assert "X-RapidAPI-Key" in called["headers"]
+    assert result == {"flights": []}


### PR DESCRIPTION
## Summary
- general rule for referencing issues in PR descriptions
- replace Kayak client with Google Flights Search client
- document obtaining the RapidAPI key
- update requirements and plan with SerpApi TODO
- add and rename tests for the new client
- require PRs that fix issue #3 to mention `closes #3`
- remove SerpApi TODO from documentation

closes #3

------
https://chatgpt.com/codex/tasks/task_e_684627d475b0833390ab8e408fbf628a