### PR TITLE
Split CI workflows and fix lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Lint
+        run: flake8

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install ruff
       - name: Lint
-        run: flake8
+        run: ruff check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
-name: CI
+name: Test
 
 on:
   pull_request:
   push:
 
 jobs:
-  lint-and-test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -15,9 +15,6 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
           pip install -r requirements.txt
-      - name: Lint
-        run: flake8
-      - name: Test
+      - name: Run tests
         run: pytest -q

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@ This repository follows the guidelines below for all contributions:
 - Keep code concise and remove unused code before committing.
 - Use typed Python where possible.
 - Before committing, ensure linting and cleanup are performed. Run
-  `ruff check --fix .` to automatically fix style issues. No lingering code
-  should remain.
+  `ruff check --fix .` to automatically fix style issues. Configure a git
+  pre-commit hook to run this automatically after installing the
+  `pre-commit` package (`pip install pre-commit` then `pre-commit install`).
+  No lingering code should remain.
 - Write tests that provide value without excess. Use GitHub workflows to run tests on shared runners.
 - Always run the test suite and ensure all tests pass before opening a pull request.
 - To interact with GitHub programmatically (e.g., creating issues), configure the environment variable `GITHUB_TOKEN` or `GH_TOKEN` with appropriate permissions.

--- a/PLAN.txt
+++ b/PLAN.txt
@@ -3,5 +3,7 @@
 - [ ] Create endpoint/tool to query flights. ([#4](https://github.com/wdvr/mcp-kayak/issues/4))
 - [x] Add tests and GitHub Actions workflow. ([#5](https://github.com/wdvr/mcp-kayak/issues/5))
 - [x] Split CI workflows for lint and tests and fix lints.
+- [x] Add pre-commit hook to run ruff fixes automatically and resolve flake8
+  issues.
 
 GitHub issues created successfully using the `GITHUB_TOKEN` environment variable.

--- a/PLAN.txt
+++ b/PLAN.txt
@@ -2,5 +2,6 @@
 - [x] Implement Google Flights API client for flight search. ([#3](https://github.com/wdvr/mcp-kayak/issues/3))
 - [ ] Create endpoint/tool to query flights. ([#4](https://github.com/wdvr/mcp-kayak/issues/4))
 - [x] Add tests and GitHub Actions workflow. ([#5](https://github.com/wdvr/mcp-kayak/issues/5))
+- [x] Split CI workflows for lint and tests and fix lints.
 
 GitHub issues created successfully using the `GITHUB_TOKEN` environment variable.

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ Run the linters and tests locally with:
 
 ```bash
 pip install -r requirements.txt
-pip install flake8
-flake8
+pre-commit install
+pre-commit run --all-files
 pytest -q
 ```
 
-All pull requests are checked by the `CI` workflow, which runs `flake8` and
-`pytest`. Mark the workflow as required in the repository settings to block
-merges when it fails.
+All pull requests are checked by the CI workflows, which run `ruff` and
+`pytest`. Mark the workflows as required in the repository settings to block
+merges when they fail.

--- a/mcp_kayak/google_flights_client.py
+++ b/mcp_kayak/google_flights_client.py
@@ -12,7 +12,11 @@ class GoogleFlightsClient:
 
     BASE_URL = "https://google-flights13.p.rapidapi.com"
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
         self.api_key = api_key or os.getenv("GOOGLE_FLIGHTS_API_KEY")
         if not self.api_key:
             raise ValueError("GOOGLE_FLIGHTS_API_KEY missing")
@@ -31,6 +35,11 @@ class GoogleFlightsClient:
         headers = {
             "X-RapidAPI-Key": self.api_key,
         }
-        resp = httpx.get(f"{self.base_url}/flights", params=params, headers=headers, timeout=10)
+        resp = httpx.get(
+            f"{self.base_url}/flights",
+            params=params,
+            headers=headers,
+            timeout=10,
+        )
         resp.raise_for_status()
         return resp.json()

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ python-dotenv
 fastapi
 httpx
 pytest
-flake8
 pre-commit
+ruff

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ fastapi
 httpx
 pytest
 flake8
+pre-commit

--- a/tests/test_google_flights_client.py
+++ b/tests/test_google_flights_client.py
@@ -2,11 +2,13 @@ import os
 import sys
 from typing import Any
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+sys.path.insert(
+    0,
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+)  # noqa: E402
 
-import pytest
-
-from mcp_kayak.google_flights_client import GoogleFlightsClient
+import pytest  # noqa: E402
+from mcp_kayak.google_flights_client import GoogleFlightsClient  # noqa: E402
 
 
 def test_init_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -19,7 +21,12 @@ def test_search_flights(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GOOGLE_FLIGHTS_API_KEY", "dummy")
     called: dict[str, Any] = {}
 
-    def fake_get(url: str, params: dict[str, Any], headers: dict[str, Any], timeout: int) -> Any:
+    def fake_get(
+        url: str,
+        params: dict[str, Any],
+        headers: dict[str, Any],
+        timeout: int,
+    ) -> Any:
         called["url"] = url
         called["params"] = params
         called["headers"] = headers

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,8 +1,7 @@
 """Tests for the FastMCP server wrapper."""
-import sys
-import os
-
 from __future__ import annotations
+
+import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,6 @@ from fastapi.testclient import TestClient  # noqa: E402
 from mcp_kayak.server import app, server  # noqa: E402
 
 
-
 def test_ping() -> None:
     client = TestClient(app)
     resp = client.get("/ping")


### PR DESCRIPTION
## Summary
- split GitHub workflow into lint and test jobs
- fix failing lint in `tests/test_server.py`
- document new CI workflow in PLAN

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462d0e2188833382fe357754f865e5