### PR TITLE
Add airport lookup endpoint

### DIFF
--- a/PLAN.txt
+++ b/PLAN.txt
@@ -6,5 +6,6 @@
 - [x] Split CI workflows for lint and tests and fix lints.
 - [x] Add pre-commit hook to run ruff fixes automatically and resolve flake8
   issues.
+- [ ] Add endpoint to resolve locations to nearest airport codes.
 
 GitHub issues created successfully using the `GITHUB_TOKEN` environment variable.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ mcp dev mcp_kayak.server:server
 
 The MCP Inspector will open in your browser and connect to the running server.
 
+### Endpoints
+
+- `GET /ping` – health check.
+- `GET /airports?location=<city>` – return the closest airport codes for a city
+  or country name.
+
 ## Testing and CI
 
 Run the linters and tests locally with:

--- a/mcp_kayak/__init__.py
+++ b/mcp_kayak/__init__.py
@@ -1,5 +1,6 @@
 """MCP Kayak server."""
 
-__all__ = ["app", "server", "TravelpayoutsClient"]
+__all__ = ["app", "server", "TravelpayoutsClient", "airports_for_location_async"]
 
 from .travelpayouts_client import TravelpayoutsClient
+from .airport_locator import airports_for_location_async

--- a/mcp_kayak/airport_locator.py
+++ b/mcp_kayak/airport_locator.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from geopy.distance import geodesic
+from geopy.geocoders import Nominatim
+import airportsdata
+
+
+def airports_for_location(location: str, limit: int = 5) -> list[dict[str, Any]]:
+    """Return nearest airports for a location."""
+    geo = Nominatim(user_agent="mcp-kayak")
+    loc = geo.geocode(location)
+    if loc is None:
+        raise ValueError("Location not found")
+    lat = loc.latitude
+    lon = loc.longitude
+
+    airports = airportsdata.load("IATA")
+    results: list[dict[str, Any]] = []
+    for code, data in airports.items():
+        if not data.get("lat") or not data.get("lon"):
+            continue
+        dist = geodesic((lat, lon), (data["lat"], data["lon"]))
+        results.append({"code": code, "name": data["name"], "distance_km": dist.km})
+    results.sort(key=lambda r: r["distance_km"])
+    return results[:limit]
+
+
+async def airports_for_location_async(location: str, limit: int = 5) -> list[dict[str, Any]]:
+    """Async wrapper for :func:`airports_for_location`."""
+    return await asyncio.to_thread(airports_for_location, location, limit)

--- a/mcp_kayak/server.py
+++ b/mcp_kayak/server.py
@@ -5,6 +5,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastmcp import FastMCP
 
+from .airport_locator import airports_for_location_async
+
 # Load environment variables from .env if present
 load_dotenv()
 
@@ -15,6 +17,13 @@ app = FastAPI(title="mcp-kayak")
 async def ping() -> dict[str, bool]:
     """Health check endpoint."""
     return {"pong": True}
+
+
+@app.get("/airports")
+async def airports(location: str, limit: int = 5) -> dict[str, list[dict[str, float | str]]]:
+    """Return closest airports for a location."""
+    results = await airports_for_location_async(location, limit)
+    return {"airports": results}
 
 
 # Convert the FastAPI application to a FastMCP server

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ httpx
 pytest
 pre-commit
 ruff
+airportsdata
+geopy

--- a/tests/test_airport_locator.py
+++ b/tests/test_airport_locator.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from mcp_kayak import airport_locator
+
+
+class DummyLoc:
+    latitude = 37.5483
+    longitude = -121.9886
+
+
+def test_airports_for_location(monkeypatch):
+    def fake_geocode(self, location: str):
+        return DummyLoc()
+
+    monkeypatch.setattr(airport_locator.Nominatim, "geocode", fake_geocode)
+    monkeypatch.setattr(
+        "airportsdata.load",
+        lambda kind: {
+            "SJC": {"name": "San Jose International", "lat": 37.3626, "lon": -121.929},
+            "OAK": {"name": "Oakland International", "lat": 37.7213, "lon": -122.221},
+        },
+    )
+
+    results = airport_locator.airports_for_location("Fremont, CA", limit=1)
+    assert results[0]["code"] == "SJC"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,6 +10,11 @@ from fastapi.testclient import TestClient  # noqa: E402
 from mcp_kayak.server import app, server  # noqa: E402
 
 
+class DummyLoc:
+    latitude = 37.5483
+    longitude = -121.9886
+
+
 def test_ping() -> None:
     client = TestClient(app)
     resp = client.get("/ping")
@@ -19,3 +24,24 @@ def test_ping() -> None:
 
 def test_server_has_run() -> None:
     assert hasattr(server, "run")
+
+
+def test_airports(monkeypatch) -> None:
+    client = TestClient(app)
+
+    def fake_geocode(self, location: str):
+        return DummyLoc()
+
+    monkeypatch.setattr("mcp_kayak.airport_locator.Nominatim.geocode", fake_geocode)
+    monkeypatch.setattr(
+        "airportsdata.load",
+        lambda kind: {
+            "SJC": {"name": "San Jose International", "lat": 37.3626, "lon": -121.929},
+            "OAK": {"name": "Oakland International", "lat": 37.7213, "lon": -122.221},
+        },
+    )
+
+    resp = client.get("/airports", params={"location": "Fremont, CA", "limit": 1})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["airports"][0]["code"] == "SJC"


### PR DESCRIPTION
## Summary
- implement location-to-airport lookup logic and async wrapper
- expose new `/airports` endpoint
- export utility in package
- add airportsdata and geopy to dependencies
- document available endpoints
- update task list
- test airport lookup logic and endpoint

## Testing
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465761b46c833381039d90b55fdb79