### PR TITLE
Expose endpoints as MCP tools

### DIFF
--- a/mcp_kayak/server.py
+++ b/mcp_kayak/server.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dotenv import load_dotenv
 from fastapi import FastAPI
 from fastmcp import FastMCP
+from fastmcp.server.openapi import MCPType, RouteMap
 
 from .airport_locator import airports_for_location_async
 
@@ -27,7 +28,17 @@ async def airports(location: str, limit: int = 5) -> dict[str, list[dict[str, fl
 
 
 # Convert the FastAPI application to a FastMCP server
-server: FastMCP = FastMCP.from_fastapi(app)
+server: FastMCP = FastMCP.from_fastapi(
+    app,
+    route_maps=[
+        RouteMap(methods=["GET"], pattern=r"/ping", mcp_type=MCPType.TOOL),
+        RouteMap(methods=["GET"], pattern=r"/airports", mcp_type=MCPType.TOOL),
+    ],
+    mcp_names={
+        "ping_ping_get": "ping",
+        "airports_airports_get": "airports",
+    },
+)
 
 
 if __name__ == "__main__":

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sys
+import asyncio
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
@@ -45,3 +46,9 @@ def test_airports(monkeypatch) -> None:
     assert resp.status_code == 200
     data = resp.json()
     assert data["airports"][0]["code"] == "SJC"
+
+
+def test_tools_available() -> None:
+    tools = asyncio.run(server.get_tools())
+    assert "ping" in tools
+    assert "airports" in tools


### PR DESCRIPTION
## Summary
- map `/ping` and `/airports` to tools when creating the server
- test that the tools are registered

## Testing
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465a9336548333a4f28e5610d5cd1f