### PR TITLE
Improve airport filtering

### DIFF
--- a/mcp_kayak/airport_locator.py
+++ b/mcp_kayak/airport_locator.py
@@ -21,10 +21,20 @@ def airports_for_location(location: str, limit: int = 5) -> list[dict[str, Any]]
     lon = loc.longitude
 
     airports = airportsdata.load("IATA")
+    major_codes: set[str] = set()
+    for mac in airportsdata.load_iata_macs().values():
+        major_codes.update(mac["airports"].keys())
+
     results: list[dict[str, Any]] = []
     for code, data in airports.items():
         if not data.get("lat") or not data.get("lon"):
             continue
+
+        name_lower = data["name"].lower()
+        is_major = "international" in name_lower or code in major_codes
+        if not is_major:
+            continue
+
         dist = geodesic((lat, lon), (data["lat"], data["lon"]))
         results.append({"code": code, "name": data["name"], "distance_km": dist.km})
     results.sort(key=lambda r: r["distance_km"])

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -41,6 +41,7 @@ def test_airports(monkeypatch) -> None:
             "OAK": {"name": "Oakland International", "lat": 37.7213, "lon": -122.221},
         },
     )
+    monkeypatch.setattr("airportsdata.load_iata_macs", lambda: {})
 
     resp = client.get("/airports", params={"location": "Fremont, CA", "limit": 1})
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- filter /airports results to only major airports
- update unit tests for new filtering logic

## Testing
- `ruff check --fix .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846614a5aac8333aa47ee73569495ad