### PR TITLE
Add currency option for flight searches

### DIFF
--- a/PLAN.txt
+++ b/PLAN.txt
@@ -8,5 +8,6 @@
   issues.
 - [ ] Add endpoint to resolve locations to nearest airport codes.
 - [x] Fix SSL certificate error when calling Nominatim for airports.
+- [ ] Allow configuring currency for flight search (default USD).
 
 GitHub issues created successfully using the `GITHUB_TOKEN` environment variable.

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ pip install -r requirements.txt
      --data-urlencode origin=NYC \
      --data-urlencode destination=LAX \
      --data-urlencode depart_date=2025-01-01 \
-     --data-urlencode token=$TRAVELPAYOUTS_APIKEY
+   --data-urlencode token=$TRAVELPAYOUTS_APIKEY
    ```
    A valid key will return JSON instead of an `Unauthorized` message.
+   Optionally set `TRAVELPAYOUTS_CURRENCY` to control the currency used for
+   flight prices (defaults to `USD`).
 
 3. Start the server using the MCP CLI with the Inspector:
 

--- a/mcp_kayak/server.py
+++ b/mcp_kayak/server.py
@@ -36,11 +36,17 @@ async def flights(
     destination: str,
     date: str,
     cabin: str = "economy",
+    currency: str | None = None,
 ) -> dict[str, object]:
     """Search for flights using Travelpayouts."""
     client = TravelpayoutsClient()
     return await asyncio.to_thread(
-        client.search_flights, origin, destination, date, cabin
+        client.search_flights,
+        origin,
+        destination,
+        date,
+        cabin,
+        currency,
     )
 
 

--- a/mcp_kayak/travelpayouts_client.py
+++ b/mcp_kayak/travelpayouts_client.py
@@ -12,14 +12,25 @@ class TravelpayoutsClient:
 
     BASE_URL = "https://api.travelpayouts.com/aviasales/v3"
 
-    def __init__(self, api_key: str | None = None, base_url: str | None = None) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        currency: str | None = None,
+    ) -> None:
         self.api_key = api_key or os.getenv("TRAVELPAYOUTS_APIKEY")
         if not self.api_key:
             raise ValueError("TRAVELPAYOUTS_APIKEY missing")
         self.base_url = base_url or self.BASE_URL
+        self.currency = currency or os.getenv("TRAVELPAYOUTS_CURRENCY", "USD")
 
     def search_flights(
-        self, origin: str, destination: str, date: str, cabin: str = "economy"
+        self,
+        origin: str,
+        destination: str,
+        date: str,
+        cabin: str = "economy",
+        currency: str | None = None,
     ) -> dict[str, Any]:
         """Query flights from the Travelpayouts API."""
         params = {
@@ -28,6 +39,7 @@ class TravelpayoutsClient:
             "depart_date": date,
             "trip_class": cabin,
             "token": self.api_key,
+            "currency": currency or self.currency,
         }
         resp = httpx.get(
             f"{self.base_url}/prices_for_dates",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -53,7 +53,11 @@ def test_flights(monkeypatch) -> None:
 
     monkeypatch.setenv("TRAVELPAYOUTS_APIKEY", "dummy")
 
+    called: dict[str, dict[str, str]] = {}
+
     def fake_get(url: str, params: dict[str, str], timeout: int):
+        called["params"] = params
+
         class Resp:
             def raise_for_status(self) -> None:
                 pass
@@ -71,6 +75,7 @@ def test_flights(monkeypatch) -> None:
     )
     assert resp.status_code == 200
     assert resp.json() == {"flights": []}
+    assert called["params"]["currency"] == "USD"
 
 
 def test_tools_available() -> None:


### PR DESCRIPTION
## Summary
- make `TravelpayoutsClient` accept a currency option
- plumb the optional currency through the `/flights` endpoint
- document `TRAVELPAYOUTS_CURRENCY` in README
- test currency behavior
- update project plan

## Testing
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846631cc1488333abe320999a91d9f6