### PR TITLE
Add return flight support

### DIFF
--- a/PLAN.txt
+++ b/PLAN.txt
@@ -11,5 +11,6 @@
 - [ ] Add Next.js frontend for querying flights. ([#22](https://github.com/wdvr/mcp-kayak/issues/22))
 - [x] Add endpoint to decode airline codes and durations.
 - [ ] Allow configuring currency for flight search (default USD).
+- [x] Support return flights with optional parameters.
 
 GitHub issues created successfully using the `GITHUB_TOKEN` environment variable.

--- a/README.md
+++ b/README.md
@@ -60,11 +60,9 @@ pip install -r requirements.txt
    the token works with a quick `curl` call:
 
    ```bash
-   curl -G https://api.travelpayouts.com/aviasales/v3/prices_for_dates \
-     --data-urlencode origin=NYC \
-     --data-urlencode destination=LAX \
-     --data-urlencode depart_date=2025-01-01 \
-   --data-urlencode token=$TRAVELPAYOUTS_APIKEY
+   curl -X POST https://api.travelpayouts.com/v1/flight_search \
+     -H 'Content-Type: application/json' \
+     -d '{"signature":"'$TRAVELPAYOUTS_APIKEY'","segments":[{"origin":"NYC","destination":"LAX","date":"2025-01-01"}]}'
    ```
    A valid key will return JSON instead of an `Unauthorized` message.
    Optionally set `TRAVELPAYOUTS_CURRENCY` to control the currency used for
@@ -96,7 +94,7 @@ with `claude -p` through the API route `/api/query`.
 
 - `GET /ping` – health check.
 - `GET /airports?location=<city>` – return the closest airport codes for a city or country name.
-- `GET /flights?origin=<code>&destination=<code>&date=YYYY-MM-DD&cabin=<class>` – search for flight options.
+- `GET /flights?origin=<code>&destination=<code>&date=YYYY-MM-DD&cabin=<class>&return_date=YYYY-MM-DD&include_return=<bool>` – search for flight options. When `include_return` is true (the default), return flights are also shown. The `return_date` parameter can specify a different date for the return leg.
 
 ## Testing and CI
 

--- a/mcp_kayak/server.py
+++ b/mcp_kayak/server.py
@@ -46,6 +46,8 @@ async def flights(
     date: str,
     cabin: str = "economy",
     currency: str | None = None,
+    return_date: str | None = None,
+    include_return: bool = True,
 ) -> dict[str, object]:
     """Search for flights using the Travelpayouts API.
 
@@ -63,6 +65,11 @@ async def flights(
     currency:
         Optional three letter ISO currency code. When omitted, the server
         default is used.
+    return_date:
+        Optional date in ``YYYY-MM-DD`` format for the return leg. When omitted,
+        the outbound ``date`` is reused.
+    include_return:
+        When ``True`` include results for the return leg as well.
     """
     client = TravelpayoutsClient()
     return await asyncio.to_thread(
@@ -72,6 +79,8 @@ async def flights(
         date,
         cabin,
         currency,
+        include_return=include_return,
+        return_date=return_date,
     )
 
 


### PR DESCRIPTION
## Summary
- support return flights in `TravelpayoutsClient.search_flights`
- expose `include_return` and `return_date` on the `/flights` endpoint
- document the new parameters in README
- update PLAN and tests for return flight logic

## Testing
- `ruff check --fix .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6846686c767c83338a677f4f0a1020c6